### PR TITLE
feat: 타임테이블 카드 시각적 구분 및 시간 범위 개선

### DIFF
--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -20,15 +20,17 @@ const TimelineCard: React.FC<TimelineCardProps> = ({
   artistInfo 
 }) => {
   return (
-    <div className="space-y-2 hover:scale-[1.02] transition-transform duration-200 ease-out">
+    <div className={`space-y-2 mt-1 hover:scale-[1.02] transition-all duration-200 ease-out ${
+      !isCurrent ? 'opacity-50' : ''
+    }`}>
       {/* 시간 표시 - 별도 박스 */}
-      <div className="bg-white/60 rounded-full px-3 py-2 mb-1 shadow-sm border border-gray-200 text-center">
-        <span className="text-sm font-bold text-gray-800">{time}</span>
+      <div className="bg-[#F2FCF3] ring-1 ring-[#285100] ring-opacity-50 rounded-full px-3 py-2 mb-1 shadow-sm border border-gray-200 text-center">
+        <span className="text-sm font-bold text-[#285100]">{time}</span>
       </div>
       
       {/* 내용 - 현재 이벤트일 때 하이라이트 */}
-      <div className={`rounded-2xl p-4 shadow-lg transition-all duration-300 ${
-        isCurrent ? 'bg-white/60 ring-2 ring-[#285100] ring-opacity-50' : 'bg-white/60'
+      <div className={`rounded-2xl p-4 ring-1 ring-[#285100] ring-opacity-50 shadow-lg transition-all duration-300 ${
+        isCurrent ? 'bg-white/60 ring-1 ring-[#285100] ring-opacity-50' : 'bg-white/60'
       }`}>
         <div className="text-center">
           <h3 className="text-base font-semibold text-gray-800 mb-1">{title}</h3>

--- a/src/pages/Timetable.tsx
+++ b/src/pages/Timetable.tsx
@@ -65,10 +65,11 @@ const Timetable: React.FC = () => {
     const now = new Date();
     const currentMinutes = now.getHours() * 60 + now.getMinutes();
     
-    // "~"로 시작하는 경우 (예: "17:00 ~")
+    // "~"로 끝나는 경우 (예: "17:00 ~") - 18:00까지 진행되는 것으로 처리
     if (timeStr.includes('~') && timeStr.endsWith('~')) {
       const startTime = timeToMinutes(timeStr);
-      return currentMinutes >= startTime;
+      const endTime = 18 * 60; // 18:00 = 1080분
+      return currentMinutes >= startTime && currentMinutes <= endTime;
     }
     
     // 시간 범위가 있는 경우 (예: "13:00 ~ 17:00")


### PR DESCRIPTION
# 타임테이블 사용자 경험 개선

## 📋 개요
타임테이블 페이지의 시각적 구분을 개선하고, 시간 범위 처리 로직을 개선했습니다.

## ✨ 주요 변경사항

### 1. 시각적 구분 개선
- 현재 시간대가 아닌 카드들의 투명도를 50%로 설정
- 현재 진행 중인 이벤트는 100% 불투명도로 강조 표시

### 2. 시간 범위 처리 개선
- "17:00 ~" 형태의 스케줄을 18:00까지 진행되는 것으로 처리
- 기존: 시작 시간부터 무제한 진행
- 개선: 17:00 ~ 18:00 범위로 제한

## 🎯 개선 효과
- ✅ **시각적 구분**: 현재 시간대와 다른 시간대를 명확히 구분
- ✅ **집중도 향상**: 현재 진행 중인 이벤트에 사용자 집중 유도
- ✅ **정확한 시간 처리**: 17:00 시작 이벤트의 실제 종료 시간 명확화

## 🔧 기술적 세부사항

### TimelineCard 컴포넌트
```tsx
<div className={`space-y-2 mt-1 hover:scale-[1.02] transition-all duration-200 ease-out ${
  !isCurrent ? 'opacity-50' : ''
}`}>
```

### 시간 범위 처리
```typescript
if (timeStr.includes('~') && timeStr.endsWith('~')) {
  const startTime = timeToMinutes(timeStr);
  const endTime = 18 * 60; // 18:00 = 1080분
  return currentMinutes >= startTime && currentMinutes <= endTime;
}
```

## 🚀 배포 후 확인사항
1. 현재 시간대 외 카드들이 50% 투명도로 표시되는지 확인
2. 17:00~18:00 사이에 "17:00 ~" 스케줄이 현재 진행 중으로 표시되는지 확인
3. 카드 투명도 변화가 부드럽게 전환되는지 확인


**작성자**: @Kim-jaeyeon
