### PR TITLE
feat: FAQ/방명록 페이지 레이아웃 개선

### DIFF
--- a/src/components/FAQItem.tsx
+++ b/src/components/FAQItem.tsx
@@ -8,7 +8,13 @@ type Props = {
     variant?: "pill" | "rounded";
 };
 
-export default function FAQItem({ question, answer, isOpen, onClick, variant }: Props) {
+export default function FAQItem({
+    question,
+    answer,
+    isOpen,
+    onClick,
+    variant,
+}: Props) {
     const autoVariant = useMemo<"pill" | "rounded">(() => {
         if (variant) return variant;
         return question.length <= 23 ? "pill" : "rounded";
@@ -33,7 +39,6 @@ export default function FAQItem({ question, answer, isOpen, onClick, variant }: 
                         : "linear-gradient(#FFFFFFCC, #FFFFFFCC) padding-box, linear-gradient(90deg,#83C082,#3E5A3D) border-box",
                 }}
             >
-                {/* 가운데 정렬 컨테이너 */}
                 <div className="flex w-full items-center justify-center relative px-[23px]">
                     <span
                         className="text-center"
@@ -48,7 +53,6 @@ export default function FAQItem({ question, answer, isOpen, onClick, variant }: 
                         {question}
                     </span>
 
-                    {/* 우측 아이콘 */}
                     <span className="absolute right-[10px] flex items-center justify-center">
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -56,7 +60,8 @@ export default function FAQItem({ question, answer, isOpen, onClick, variant }: 
                             height="8"
                             viewBox="0 0 16 8"
                             fill="none"
-                            className={`transition-transform duration-200 ${isOpen ? "" : "rotate-180"}`}
+                            className={`transition-transform duration-200 ${isOpen ? "" : "rotate-180"
+                                }`}
                         >
                             <path
                                 d="M8.00008 0.74998L0.916748 7.83331H15.0834L8.00008 0.74998Z"
@@ -68,23 +73,24 @@ export default function FAQItem({ question, answer, isOpen, onClick, variant }: 
                 </div>
             </button>
 
-            {/* 답변 카드 */}
-            {isOpen && (
-                <div
-                    className="mt-[3px] flex flex-col justify-center items-center flex-shrink-0 mx-[-1px] rounded-[17px]"
-                    style={{
-                        background:
-                            "linear-gradient(0deg, rgba(255,255,255,0.80) 0%, rgba(255,255,255,0.80) 100%), rgba(69,130,68,0.17)",
-                        boxShadow:
-                            "0 0 19.4px 7px rgba(255,255,255,0.26) inset, -1px 3px 13.1px -4px rgba(56,63,41,0.67)",
-                        padding: "0px 14px",
-                    }}
+            {/* 답변 카드 (opacity + scaleY로 자연스럽게) */}
+            <div
+                className="mt-[3px] mx-[-1px] rounded-[17px] px-[14px]"
+                style={{
+                    background:
+                        "linear-gradient(0deg, rgba(255,255,255,0.80) 0%, rgba(255,255,255,0.80) 100%), rgba(69,130,68,0.17)",
+                    boxShadow:
+                        "0 0 19.4px 7px rgba(255,255,255,0.26) inset, -1px 3px 13.1px -4px rgba(56,63,41,0.67)",
+                }}
+            >
+                <p
+                    className={`text-[#1B1B1B] text-center font-pretendard font-[300] text-[15px] whitespace-pre-line leading-relaxed transition-opacity duration-300 ${isOpen ? "opacity-100 visible py-[9px]" : "opacity-0 invisible h-0 py-0"
+                        }`}
                 >
-                    <p className="mt-[9px] mb-[10px] text-[#1B1B1B] text-center font-pretendard font-[300] text-[15px] whitespace-pre-line leading-relaxed">
-                        {answer}
-                    </p>
-                </div>
-            )}
+                    {answer}
+                </p>
+            </div>
+
         </div>
     );
 }

--- a/src/pages/FAQAndGuestbook.tsx
+++ b/src/pages/FAQAndGuestbook.tsx
@@ -8,53 +8,52 @@ import api from "../utils/api";
 const FAQ_DATA = [
   {
     q: "HORTUS는 어떤 의미인가요?",
-    a: "HORTUS는 라틴어로 '정원'을 의미하며, 슬로건 '고요를 채울, 환희로 피어날'은 학우 여러분이 함께 어우러져 축제를 완성한다는 의미를 담고 있습니다."
+    a: "HORTUS는 라틴어로 '정원'을 의미하며, 슬로건 '고요를 채울, 환희로 피어날'은 학우 여러분이 함께 어우러져 축제를 완성한다는 의미를 담고 있습니다.",
   },
   {
     q: "베스트 포토 이벤트 참여 방법은 무엇인가요?",
-    a: "축제 기간 촬영한 사진을 공식 웹사이트에 업로드 후, 선정된 사진은 축제 스케치 사진 상영회에서 방영됩니다."
+    a: "축제 기간 촬영한 사진을 공식 웹사이트에 업로드 후, 선정된 사진은 축제 스케치 사진 상영회에서 방영됩니다.",
   },
   {
     q: "공연 당일 우천 시에도 공연이 진행되나요?",
-    a: "대부분 공연은 예정대로 진행되지만, 안전을 위해 일부 프로그램은 변경 또는 취소될 수 있습니다. 현장 안내를 확인해주세요."
+    a: "대부분 공연은 예정대로 진행되지만, 안전을 위해 일부 프로그램은 변경 또는 취소될 수 있습니다. 현장 안내를 확인해주세요.",
   },
   {
     q: "대동제 주점은 몇 시까지 운영되나요?",
-    a: "60주년 기념관 및 미래광장 주점 모두 18:00~24:00 운영되며, 주류 판매는 23:30까지입니다."
+    a: "60주년 기념관 및 미래광장 주점 모두 18:00~24:00 운영되며, 주류 판매는 23:30까지입니다.",
   },
   {
     q: "주문은 미리 예약하고 들어가야 하나요?",
-    a: "일부 부스는 사전 예약이 필요할 수 있습니다. 참여 전 부스별 안내를 확인해주세요."
+    a: "일부 부스는 사전 예약이 필요할 수 있습니다. 참여 전 부스별 안내를 확인해주세요.",
   },
   {
     q: "주점은 미리 예약해야 하나요? 예약 안 되어 있으면 어디로 연락하나요?",
-    a: "주점은 일반적으로 예약 없이 이용 가능합니다. 예약 관련 문의는 집행위원회 공식 연락처를 통해 안내받으실 수 있습니다."
+    a: "주점은 일반적으로 예약 없이 이용 가능합니다. 예약 관련 문의는 집행위원회 공식 연락처를 통해 안내받으실 수 있습니다.",
   },
   {
     q: "부스 참여 혜택이 있나요?",
-    a: "체험 부스 참여 후 판매 부스 상품권을 받을 수 있으며, 현수막 키워드 찾기, 베스트 포토, 부스플래닛 등 다양한 참여 이벤트가 준비되어 있습니다."
+    a: "체험 부스 참여 후 판매 부스 상품권을 받을 수 있으며, 현수막 키워드 찾기, 베스트 포토, 부스플래닛 등 다양한 참여 이벤트가 준비되어 있습니다.",
   },
   {
     q: "푸드트럭은 어디서 운영되나요?",
-    a: "푸드트럭은 60주년 기념관과 미래광장에 운영될 예정이며, 메뉴와 가격은 현장 안내를 확인해주세요."
+    a: "푸드트럭은 60주년 기념관과 미래광장에 운영될 예정이며, 메뉴와 가격은 현장 안내를 확인해주세요.",
   },
   {
     q: "재학생 무대에 참여하고 싶다면 어떻게 하나요?",
-    a: "KNU Artist 프로그램(가요제, 밴드제, 댄스제)에 참여하려면 중앙동아리 소속이거나 집행위원회에 문의해야 합니다."
+    a: "KNU Artist 프로그램(가요제, 밴드제, 댄스제)에 참여하려면 중앙동아리 소속이거나 집행위원회에 문의해야 합니다.",
   },
   {
     q: "사진 촬영과 SNS 공유가 가능한가요?",
-    a: "네, 가능하며 베스트 포토 이벤트 참여 시 공식 웹사이트에 사진 업로드 후 선정될 수 있습니다."
+    a: "네, 가능하며 베스트 포토 이벤트 참여 시 공식 웹사이트에 사진 업로드 후 선정될 수 있습니다.",
   },
   {
     q: "전야제는 누구나 참여할 수 있나요?",
-    a: "재학생뿐 아니라 방문객 누구나 참여 가능합니다."
+    a: "재학생뿐 아니라 방문객 누구나 참여 가능합니다.",
   },
   {
     q: "부스 상품권 이벤트 참여 방법은 무엇인가요?",
-    a: "체험 부스 참여 후 상품권을 수령하며, 판매 부스에서 현금처럼 사용 가능합니다. 선착순 200명 대상입니다."
+    a: "체험 부스 참여 후 상품권을 수령하며, 판매 부스에서 현금처럼 사용 가능합니다. 선착순 200명 대상입니다.",
   },
-
 ];
 
 interface GuestbookItem {
@@ -83,7 +82,6 @@ const FAQAndGuestbook: React.FC = () => {
   }, [location.pathname]);
 
   // 서버에서 방명록 목록 가져오기
-  // 서버에서 방명록 목록 가져오기
   useEffect(() => {
     if (activeTab !== "guestbook") return;
 
@@ -97,7 +95,6 @@ const FAQAndGuestbook: React.FC = () => {
         }
       } catch (err: any) {
         console.error("방명록 조회 오류:", err);
-        // 401 처리 등은 api.ts에서 자동
         alert("방명록 불러오기 실패 또는 로그인 필요");
         navigate("/login");
       }
@@ -105,6 +102,7 @@ const FAQAndGuestbook: React.FC = () => {
 
     fetchGuestbooks();
   }, [activeTab, navigate]);
+
   const handleTabChange = (tab: "faq" | "guestbook") => {
     setActiveTab(tab);
   };
@@ -152,7 +150,8 @@ const FAQAndGuestbook: React.FC = () => {
         {/* 콘텐츠 영역 */}
         <section className="px-4 mt-6 pb-6">
           {activeTab === "faq" ? (
-            <div className="space-y-4">
+            // ✅ FAQ 스크롤 영역
+            <div className="space-y-4 h-[calc(100vh-220px)] overflow-y-auto">
               {FAQ_DATA.map((item, index) => (
                 <FAQItem
                   key={index}
@@ -164,22 +163,15 @@ const FAQAndGuestbook: React.FC = () => {
                   }
                 />
               ))}
-
-              {/* 안내 문구를 FAQ 탭 맨 아래에만 출력 */}
-              <p className="mt-6 text-center font-pretendard text-white text-[14px] font-bold leading-[22px]">
-                자세한 내용은 @knuch_2025 로 문의 부탁드립니다
-              </p>
-
-
             </div>
           ) : (
-            <div className="space-y-4">
+            // ✅ 방명록 스크롤 영역
+            <div className="space-y-4 h-[calc(100vh-220px)] overflow-y-auto">
               {guestbooks.map((comment) => (
                 <div
                   key={comment.guestbookId}
                   className="w-full max-w-[353px] mx-auto rounded-[20px] bg-white/80 px-4 py-3 shadow-md"
                 >
-                  {/* 작성자 정보 */}
                   <div className="flex items-center gap-3 mb-2">
                     <div className="w-[28px] h-[28px] flex items-center justify-center rounded-[14px] bg-[#C7FBC2] overflow-hidden">
                       <img
@@ -204,7 +196,6 @@ const FAQAndGuestbook: React.FC = () => {
                     </div>
                   </div>
 
-                  {/* 내용 */}
                   <p className="font-pretendard text-[#000000] text-sm leading-relaxed mb-2">
                     {comment.content}
                   </p>
@@ -213,6 +204,10 @@ const FAQAndGuestbook: React.FC = () => {
             </div>
           )}
         </section>
+
+        <p className="text-center font-pretendard text-white text-[14px] font-bold leading-[22px]">
+          자세한 내용은 @knuch_2025 로 문의 부탁드립니다
+        </p>
       </main>
     </div>
   );


### PR DESCRIPTION
### 변경 사항
- FAQ | 방명록 탭 고정 유지
- FAQ/방명록 리스트를 내부 스크롤 영역으로 분리
- FAQ 안내 문구를 스크롤 박스 외부 하단에 고정 배치
- 배경 이미지 고정 처리로 레이아웃 흔들림 방지